### PR TITLE
Bump ember-getowner-polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "broccoli-merge-trees": "^1.0.0",
     "ember-cli-babel": "^5.1.7",
     "ember-cli-htmlbars": "^1.1.1",
-    "ember-getowner-polyfill": "^1.2.2",
+    "ember-getowner-polyfill": "^2.0.1",
     "ember-wormhole": "^0.5.1",
     "mobiledoc-dom-renderer": "^0.6.5"
   },


### PR DESCRIPTION
The dependency linter warns me that all my addons are on 2.0.0 but this one, so I bumped it.